### PR TITLE
Add vm with datadisk

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "vm_ids" {
   description = "Virtual machine ids created."
-  value       = "${concat(azurerm_virtual_machine.vm-windows.*.id, azurerm_virtual_machine.vm-linux.*.id)}"
+  value       = "${concat(azurerm_virtual_machine.vm-windows.*.id, azurerm_virtual_machine.vm-windows-with-datadisk.*.id, azurerm_virtual_machine.vm-linux.*.id, azurerm_virtual_machine.vm-linux-with-datadisk.*.id)}"
 }
 
 output "network_interface_ids" {


### PR DESCRIPTION
Hello,

I just added `azurerm_virtual_machine.vm-{OS}-with-datadisk.*.id`.
We are able to get vm_ids output from vm with datadisk.

Thanks.
Regars.